### PR TITLE
update private routes condition

### DIFF
--- a/Lab-26/modules/aws_network/main.tf
+++ b/Lab-26/modules/aws_network/main.tf
@@ -90,7 +90,7 @@ resource "aws_route_table" "private_subnets" {
 
 
 resource "aws_route_table_association" "private_routes" {
-  count          = length(aws_subnet.private_subnets[*].id)
+  count          = length(var.private_subnet_cidrs)
   route_table_id = aws_route_table.private_subnets[count.index].id
   subnet_id      = aws_subnet.private_subnets[count.index].id
 }


### PR DESCRIPTION
it is needed if you pass empty list  of private subnets from module then the `terraform plan` will fail.